### PR TITLE
Now create-models.sh actually works

### DIFF
--- a/4x6.patch
+++ b/4x6.patch
@@ -1,30 +1,37 @@
 diff --git a/src/dactyl_keyboard/dactyl.clj b/src/dactyl_keyboard/dactyl.clj
-index d8861fb..e58302f 100644
+index fc59f1f..93a0934 100644
 --- a/src/dactyl_keyboard/dactyl.clj
 +++ b/src/dactyl_keyboard/dactyl.clj
-@@ -13,13 +13,13 @@
- ;; Shape parameters ;;
+@@ -12,12 +12,12 @@
  ;;;;;;;;;;;;;;;;;;;;;;
  
--(def nrows 4)
+ (def nrows 4)
 -(def ncols 5)
-+(def nrows 4)
 +(def ncols 6)
  
- (def α (/ π 12))                        ; curvature of the columns
- (def β (/ π 36))                        ; curvature of the rows
- (def centerrow (- nrows 3))             ; controls front-back tilt
--(def centercol 3)                       ; controls left-right tilt / tenting (higher number is more tenting)
-+(def centercol 2)                       ; controls left-right tilt / tenting (higher number is more tenting)
- (def tenting-angle (/ π 12))            ; or, change this for more precise tenting control
- (def column-style 
-   (if (> nrows 5) :orthographic :standard))  ; options include :standard, :orthographic, and :fixed
-@@ -32,7 +32,7 @@
+ (def column-curvature (deg2rad 17))                         ; 15                        ; curvature of the columns
+ (def row-curvature (deg2rad 6))                             ; 5                   ; curvature of the rows
+ (def centerrow 1.75)                              ; controls front-back tilt
+-(def centercol 3)                                           ; controls left-right tilt / tenting (higher number is more tenting)
++(def centercol 2)                                           ; controls left-right tilt / tenting (higher number is more tenting)
+ (def tenting-angle (deg2rad 15))                            ; or, change this for more precise tenting control
+ (def column-style
+   (if (> nrows 5) :orthographic :standard))
+@@ -29,7 +29,7 @@
  
- (def thumb-offsets [6 -3 7])
+ (def thumb-offsets [10 -5 1])
  
--(def keyboard-z-offset 9)               ; controls overall height; original=9 with centercol=3; use 16 for centercol=2
-+(def keyboard-z-offset 16)              ; controls overall height; original=9 with centercol=3; use 16 for centercol=2
+-(def keyboard-z-offset 7)                                   ; controls overall height; original=9 with centercol=3; use 16 for centercol=2
++(def keyboard-z-offset 16)                                   ; controls overall height; original=9 with centercol=3; use 16 for centercol=2
+ (def bottom-height 2)                                    ; plexiglass plate or printed plate
+ (def extra-width 3)                                       ; extra space between the base of keys; original= 2
+ (def extra-height -0.5)                                      ; original= 0.5
+@@ -548,7 +548,7 @@
+ (def usb-holder (mirror [-1 0 0]
+                     (import "../things/holder v8.stl")))
  
- (def extra-width 2.5)                   ; extra space between the base of keys; original= 2
- (def extra-height 1.0)                  ; original= 0.5
+-(def usb-holder (translate [-40.8 45.5 bottom-height] usb-holder))
++(def usb-holder (translate [-22 45.5 bottom-height] usb-holder))
+ (def usb-holder-space
+   (translate [0 0 (/ (+  bottom-height 8.2) 2)]
+   (extrude-linear {:height (+ bottom-height 8.2) :twist 0 :convexity 0}

--- a/5x6.patch
+++ b/5x6.patch
@@ -1,8 +1,8 @@
 diff --git a/src/dactyl_keyboard/dactyl.clj b/src/dactyl_keyboard/dactyl.clj
-index d8861fb..e58302f 100644
+index fc59f1f..5cf0c42 100644
 --- a/src/dactyl_keyboard/dactyl.clj
 +++ b/src/dactyl_keyboard/dactyl.clj
-@@ -13,13 +13,13 @@
+@@ -11,13 +11,13 @@
  ;; Shape parameters ;;
  ;;;;;;;;;;;;;;;;;;;;;;
  
@@ -11,20 +11,42 @@ index d8861fb..e58302f 100644
 +(def nrows 5)
 +(def ncols 6)
  
- (def α (/ π 12))                        ; curvature of the columns
- (def β (/ π 36))                        ; curvature of the rows
- (def centerrow (- nrows 3))             ; controls front-back tilt
--(def centercol 3)                       ; controls left-right tilt / tenting (higher number is more tenting)
-+(def centercol 2)                       ; controls left-right tilt / tenting (higher number is more tenting)
- (def tenting-angle (/ π 12))            ; or, change this for more precise tenting control
- (def column-style 
-   (if (> nrows 5) :orthographic :standard))  ; options include :standard, :orthographic, and :fixed
-@@ -32,7 +32,7 @@
+ (def column-curvature (deg2rad 17))                         ; 15                        ; curvature of the columns
+ (def row-curvature (deg2rad 6))                             ; 5                   ; curvature of the rows
+ (def centerrow 1.75)                              ; controls front-back tilt
+-(def centercol 3)                                           ; controls left-right tilt / tenting (higher number is more tenting)
++(def centercol 2)                                           ; controls left-right tilt / tenting (higher number is more tenting)
+ (def tenting-angle (deg2rad 15))                            ; or, change this for more precise tenting control
+ (def column-style
+   (if (> nrows 5) :orthographic :standard))
+@@ -29,7 +29,7 @@
  
- (def thumb-offsets [6 -3 7])
+ (def thumb-offsets [10 -5 1])
  
--(def keyboard-z-offset 9)               ; controls overall height; original=9 with centercol=3; use 16 for centercol=2
-+(def keyboard-z-offset 16)              ; controls overall height; original=9 with centercol=3; use 16 for centercol=2
+-(def keyboard-z-offset 7)                                   ; controls overall height; original=9 with centercol=3; use 16 for centercol=2
++(def keyboard-z-offset 10)                                   ; controls overall height; original=9 with centercol=3; use 16 for centercol=2
+ (def bottom-height 2)                                    ; plexiglass plate or printed plate
+ (def extra-width 3)                                       ; extra space between the base of keys; original= 2
+ (def extra-height -0.5)                                      ; original= 0.5
+@@ -527,9 +527,9 @@
+   (union (screw-insert 2 0 bottom-radius top-radius height [-4 4.5 bottom-height]) ; top middle
+          (screw-insert 0 1 bottom-radius top-radius height [-5.3 -8 bottom-height]) ; left
+          (screw-insert 0 lastrow bottom-radius top-radius height [-12 -7 bottom-height]) ;thumb
+-         (screw-insert (- lastcol 1) lastrow bottom-radius top-radius height [10 13.5 bottom-height]) ; bottom right
+-         (screw-insert (- lastcol 1) 0 bottom-radius top-radius height [7 5 bottom-height]) ; top right
+-         (screw-insert 2 (+ lastrow 1) bottom-radius top-radius height [0 6.5 bottom-height]))) ;bottom middle
++         (screw-insert (- lastcol 1) lastrow bottom-radius top-radius height [10 13 bottom-height]) ; bottom right
++         (screw-insert (- lastcol 1) 0 bottom-radius top-radius height [10 5 bottom-height]) ; top right
++         (screw-insert 2 (+ lastrow 1) bottom-radius top-radius height [0 3.5 bottom-height]))) ;bottom middle
  
- (def extra-width 2.5)                   ; extra space between the base of keys; original= 2
- (def extra-height 1.0)                  ; original= 0.5
+ ; Hole Depth Y: 4.4
+ (def screw-insert-height 4)
+@@ -548,7 +548,7 @@
+ (def usb-holder (mirror [-1 0 0]
+                     (import "../things/holder v8.stl")))
+ 
+-(def usb-holder (translate [-40.8 45.5 bottom-height] usb-holder))
++(def usb-holder (translate [-22 45.5 bottom-height] usb-holder))
+ (def usb-holder-space
+   (translate [0 0 (/ (+  bottom-height 8.2) 2)]
+   (extrude-linear {:height (+ bottom-height 8.2) :twist 0 :convexity 0}

--- a/6x6.patch
+++ b/6x6.patch
@@ -1,8 +1,8 @@
 diff --git a/src/dactyl_keyboard/dactyl.clj b/src/dactyl_keyboard/dactyl.clj
-index d8861fb..e58302f 100644
+index fc59f1f..756f508 100644
 --- a/src/dactyl_keyboard/dactyl.clj
 +++ b/src/dactyl_keyboard/dactyl.clj
-@@ -13,13 +13,13 @@
+@@ -11,13 +11,13 @@
  ;; Shape parameters ;;
  ;;;;;;;;;;;;;;;;;;;;;;
  
@@ -11,20 +11,48 @@ index d8861fb..e58302f 100644
 +(def nrows 6)
 +(def ncols 6)
  
- (def α (/ π 12))                        ; curvature of the columns
- (def β (/ π 36))                        ; curvature of the rows
- (def centerrow (- nrows 3))             ; controls front-back tilt
--(def centercol 3)                       ; controls left-right tilt / tenting (higher number is more tenting)
-+(def centercol 2)                       ; controls left-right tilt / tenting (higher number is more tenting)
- (def tenting-angle (/ π 12))            ; or, change this for more precise tenting control
- (def column-style 
-   (if (> nrows 5) :orthographic :standard))  ; options include :standard, :orthographic, and :fixed
-@@ -32,7 +32,7 @@
+-(def column-curvature (deg2rad 17))                         ; 15                        ; curvature of the columns
++(def column-curvature (deg2rad 12))                         ; 15                        ; curvature of the columns
+ (def row-curvature (deg2rad 6))                             ; 5                   ; curvature of the rows
+ (def centerrow 1.75)                              ; controls front-back tilt
+-(def centercol 3)                                           ; controls left-right tilt / tenting (higher number is more tenting)
++(def centercol 2)                                           ; controls left-right tilt / tenting (higher number is more tenting)
+ (def tenting-angle (deg2rad 15))                            ; or, change this for more precise tenting control
+ (def column-style
+   (if (> nrows 5) :orthographic :standard))
+@@ -29,7 +29,7 @@
  
- (def thumb-offsets [6 -3 7])
+ (def thumb-offsets [10 -5 1])
  
--(def keyboard-z-offset 9)               ; controls overall height; original=9 with centercol=3; use 16 for centercol=2
-+(def keyboard-z-offset 16)              ; controls overall height; original=9 with centercol=3; use 16 for centercol=2
+-(def keyboard-z-offset 7)                                   ; controls overall height; original=9 with centercol=3; use 16 for centercol=2
++(def keyboard-z-offset 16)                                   ; controls overall height; original=9 with centercol=3; use 16 for centercol=2
+ (def bottom-height 2)                                    ; plexiglass plate or printed plate
+ (def extra-width 3)                                       ; extra space between the base of keys; original= 2
+ (def extra-height -0.5)                                      ; original= 0.5
+@@ -524,12 +524,12 @@
+          (translate (map + offset [(first position) (second position) (/ height 2)])))))
  
- (def extra-width 2.5)                   ; extra space between the base of keys; original= 2
- (def extra-height 1.0)                  ; original= 0.5
+ (defn screw-insert-all-shapes [bottom-radius top-radius height]
+-  (union (screw-insert 2 0 bottom-radius top-radius height [-4 4.5 bottom-height]) ; top middle
++  (union (screw-insert 2 0 bottom-radius top-radius height [-4 5 bottom-height]) ; top middle
+          (screw-insert 0 1 bottom-radius top-radius height [-5.3 -8 bottom-height]) ; left
+-         (screw-insert 0 lastrow bottom-radius top-radius height [-12 -7 bottom-height]) ;thumb
+-         (screw-insert (- lastcol 1) lastrow bottom-radius top-radius height [10 13.5 bottom-height]) ; bottom right
+-         (screw-insert (- lastcol 1) 0 bottom-radius top-radius height [7 5 bottom-height]) ; top right
+-         (screw-insert 2 (+ lastrow 1) bottom-radius top-radius height [0 6.5 bottom-height]))) ;bottom middle
++         (screw-insert 0 lastrow bottom-radius top-radius height [-12 -9 bottom-height]) ;thumb
++         (screw-insert (- lastcol 1) lastrow bottom-radius top-radius height [10 11 bottom-height]) ; bottom right
++         (screw-insert (- lastcol 1) 0 bottom-radius top-radius height [10 5 bottom-height]) ; top right
++         (screw-insert 2 (+ lastrow 1) bottom-radius top-radius height [0 1 bottom-height]))) ;bottom middle
+ 
+ ; Hole Depth Y: 4.4
+ (def screw-insert-height 4)
+@@ -548,7 +548,7 @@
+ (def usb-holder (mirror [-1 0 0]
+                     (import "../things/holder v8.stl")))
+ 
+-(def usb-holder (translate [-40.8 45.5 bottom-height] usb-holder))
++(def usb-holder (translate [-25.5 45.5 bottom-height] usb-holder))
+ (def usb-holder-space
+   (translate [0 0 (/ (+  bottom-height 8.2) 2)]
+   (extrude-linear {:height (+ bottom-height 8.2) :twist 0 :convexity 0}

--- a/create-models.sh
+++ b/create-models.sh
@@ -1,43 +1,58 @@
-lein run src/dactyl_keyboard/dactyl.clj
+echo 'Generating 4x5 .scad files...'
+echo '(load-file "src/dactyl_keyboard/dactyl.clj")' | lein repl > /dev/null 2>&1 
+echo 'Rendering 4x5 files...'
 cp things/right.scad things/right-4x5.scad
-cp things/left.scad things/left-4x5.scad
-cp things/right-plate.scad things/right-4x5-plate.scad
-openscad -o things/right-4x5-plate.dxf things/right-4x5-plate.scad >/dev/null 2>&1 &
-openscad -o things/right-4x5.stl things/right-4x5.scad >/dev/null 2>&1 &
-openscad -o things/left-4x5.stl  things/left-4x5.scad >/dev/null 2>&1 &
+cp things/right-plate-print.scad things/right-4x5-plate-print.scad
+cp things/right-plate-cut.scad things/right-4x5-plate-cut.scad
+cp things/test.scad things/test-4x5.scad
+cp things/test2.scad things/test2-4x5.scad
+openscad -o things/right-4x5-plate-cut.dxf things/right-4x5-plate-cut.scad > /dev/null 2>&1 &
+openscad -o things/right-4x5-plate-print.stl things/right-4x5-plate-print.scad > /dev/null 2>&1 &
+openscad -o things/right-4x5.stl things/right-4x5.scad > /dev/null 2>&1 &
 
-patch -p1 < 4x6.patch 
-lein run src/dactyl_keyboard/dactyl.clj
+echo 'Generating 4x6 .scad files...'
+patch -p1 < 4x6.patch > /dev/null 2>&1 
+echo '(load-file "src/dactyl_keyboard/dactyl.clj")' | lein repl > /dev/null 2>&1
+echo 'Rendering 4x6 files...'
 cp things/right.scad things/right-4x6.scad
-cp things/left.scad things/left-4x6.scad
-cp things/right-plate.scad things/right-4x6-plate.scad
-openscad -o things/right-4x6-plate.dxf things/right-4x6-plate.scad >/dev/null 2>&1 &
-openscad -o things/right-4x6.stl things/right-4x6.scad >/dev/null 2>&1  &
-openscad -o things/left-4x6.stl  things/left-4x6.scad >/dev/null 2>&1 &
-git checkout src/dactyl_keyboard/dactyl.clj
+cp things/right-plate-print.scad things/right-4x6-plate-print.scad
+cp things/right-plate-cut.scad things/right-4x6-plate-cut.scad
+cp things/test.scad things/test-4x6.scad
+cp things/test2.scad things/test2-4x6.scad
+openscad -o things/right-4x6-plate-cut.dxf things/right-4x6-plate-cut.scad > /dev/null 2>&1 &
+openscad -o things/right-4x6-plate-print.stl things/right-4x6-plate-print.scad > /dev/null 2>&1 &
+openscad -o things/right-4x6.stl things/right-4x6.scad > /dev/null 2>&1 &
+git checkout src/dactyl_keyboard/dactyl.clj > /dev/null 2>&1 
 
-patch -p1 < 5x6.patch 
-lein run src/dactyl_keyboard/dactyl.clj
+echo 'Generating 5x6 .scad files...'
+patch -p1 < 5x6.patch > /dev/null 2>&1 
+echo '(load-file "src/dactyl_keyboard/dactyl.clj")' | lein repl > /dev/null 2>&1
+echo 'Rendering 5x6 files...'
 cp things/right.scad things/right-5x6.scad
-cp things/left.scad things/left-5x6.scad
-cp things/right-plate.scad things/right-5x6-plate.scad
-openscad -o things/right-5x6-plate.dxf things/right-5x6-plate.scad >/dev/null 2>&1 &
-openscad -o things/right-5x6.stl things/right-5x6.scad >/dev/null 2>&1  &
-openscad -o things/left-5x6.stl  things/left-5x6.scad >/dev/null 2>&1 &
-git checkout src/dactyl_keyboard/dactyl.clj
+cp things/right-plate-print.scad things/right-5x6-plate-print.scad
+cp things/right-plate-cut.scad things/right-5x6-plate-cut.scad
+cp things/test.scad things/test-5x6.scad
+cp things/test2.scad things/test2-5x6.scad
+openscad -o things/right-5x6-plate-cut.dxf things/right-5x6-plate-cut.scad > /dev/null 2>&1 &
+openscad -o things/right-5x6-plate-print.stl things/right-5x6-plate-print.scad > /dev/null 2>&1 &
+openscad -o things/right-5x6.stl things/right-5x6.scad > /dev/null 2>&1 &
+git checkout src/dactyl_keyboard/dactyl.clj > /dev/null 2>&1 
 
-patch -p1 < 6x6.patch 
-lein run src/dactyl_keyboard/dactyl.clj
+echo 'Generating 6x6 .scad files...'
+patch -p1 < 6x6.patch > /dev/null 2>&1 
+echo '(load-file "src/dactyl_keyboard/dactyl.clj")' | lein repl > /dev/null 2>&1
+echo 'Rendering 6x6 files...'
 cp things/right.scad things/right-6x6.scad
-cp things/left.scad things/left-6x6.scad
-cp things/right-plate.scad things/right-6x6-plate.scad
-openscad -o things/right-6x6-plate.dxf things/right-6x6-plate.scad >/dev/null 2>&1 &
-openscad -o things/right-6x6.stl things/right-6x6.scad >/dev/null 2>&1  &
-openscad -o things/left-6x6.stl  things/left-6x6.scad >/dev/null 2>&1 &
-git checkout src/dactyl_keyboard/dactyl.clj
+cp things/right-plate-print.scad things/right-6x6-plate-print.scad
+cp things/right-plate-cut.scad things/right-6x6-plate-cut.scad
+cp things/test.scad things/test-6x6.scad
+cp things/test2.scad things/test2-6x6.scad
+openscad -o things/right-6x6-plate-cut.dxf things/right-6x6-plate-cut.scad > /dev/null 2>&1 &
+openscad -o things/right-6x6-plate-print.stl things/right-6x6-plate-print.scad > /dev/null 2>&1 &
+openscad -o things/right-6x6.stl things/right-6x6.scad > /dev/null 2>&1 &
+git checkout src/dactyl_keyboard/dactyl.clj > /dev/null 2>&1 
 
+cd things/
+rm right.scad right-plate-print.scad right-plate-cut.scad test.scad test2.scad
 
-# git add things/*-4x5.stl
-# git add things/right-4x5-plate.dxf
-# git commit -m "Add CAD files"
 wait

--- a/src/dactyl_keyboard/dactyl.clj
+++ b/src/dactyl_keyboard/dactyl.clj
@@ -12,7 +12,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;
 
 (def nrows 4)
-(def ncols 6)
+(def ncols 5)
 
 (def column-curvature (deg2rad 17))                         ; 15                        ; curvature of the columns
 (def row-curvature (deg2rad 6))                             ; 5                   ; curvature of the rows
@@ -528,7 +528,7 @@
          (screw-insert 0 1 bottom-radius top-radius height [-5.3 -8 bottom-height]) ; left
          (screw-insert 0 lastrow bottom-radius top-radius height [-12 -7 bottom-height]) ;thumb
          (screw-insert (- lastcol 1) lastrow bottom-radius top-radius height [10 13.5 bottom-height]) ; bottom right
-         (screw-insert (- lastcol 1) 0 bottom-radius top-radius height [10 5 bottom-height]) ; top right
+         (screw-insert (- lastcol 1) 0 bottom-radius top-radius height [7 5 bottom-height]) ; top right
          (screw-insert 2 (+ lastrow 1) bottom-radius top-radius height [0 6.5 bottom-height]))) ;bottom middle
 
 ; Hole Depth Y: 4.4
@@ -679,4 +679,3 @@
                          bottom-wall-usb-holder
                          thumb-space-below
                          (screw-insert-all-shapes 1 1 50)))))))
-

--- a/things/readme.md
+++ b/things/readme.md
@@ -1,1 +1,0 @@
-Please see the releases section in github for stl & scad files.


### PR DESCRIPTION
The script create-models.sh was outdated and didn't work. I updated both the script and de *.patch files to generate automatically the .scad and .stl models. I had to fix the positioning of the screw inserts and the trrs-arduino holder. In the 6x6 model i also fixed the curvature so the first and last switches of every row can fit. I modified dactyl.clj so by default it generates a 4x5 model. README.MD should probably be updated too as the instructions are simpler now. Just need to install Clojure runtime, Leiningen, openscad and execute create-models.sh to get all the .stl ready to print.